### PR TITLE
CBSP-376 Enable linked clone for provisioning with Virtualbox

### DIFF
--- a/Top_Level_Vagrantfile
+++ b/Top_Level_Vagrantfile
@@ -209,6 +209,7 @@ Vagrant.configure("2") do |config|
     vb.cpus = num_cpus
     vb.customize ["modifyvm", :id, "--ioapic", "on"]
     vb.customize ["modifyvm", :id, "--natdnshostresolver1", "#{vpn}"]
+    vb.linked_clone = true if Vagrant::VERSION >= "1.8.0"
   end
   config.vm.provider :libvirt do |libvirt|
     libvirt.memory = ram_in_MB


### PR DESCRIPTION
By using linked clones, provisioning should be faster and the amount of disk space used should be less.