### PR TITLE
Fixed the filename to the top level vagrant file for Windows

### DIFF
--- a/windows/Vagrantfile
+++ b/windows/Vagrantfile
@@ -3,5 +3,5 @@ version = "cbdev"
 
 # Read and execute the top level Vagrantfile
 Dir.chdir File.dirname(__FILE__)
-external = File.read '../Vagrantfile'
+external = File.read '../Top_Level_Vagrantfile'
 eval external


### PR DESCRIPTION
The windows vagrant file was not looking for the right top level vagrant file.