### PR TITLE
CBSP-602: Refactor to extract settings to separate file

### DIFF
--- a/Top_Level_Vagrantfile
+++ b/Top_Level_Vagrantfile
@@ -1,154 +1,14 @@
 # System for quickly and painlessly provisioning Couchbase Server virtual machines across multiple Couchbase versions and OS's.
 # See README.md for usage instructions
 
-### Variable declarations - FEEL FREE TO EDIT THESE ###
 begin
-ip_addresses = { # Values for both OS's and Couchbase versions that are cat'd together to form a full ip address
-  "centos5"  => 110,
-  "centos6"  => 111,
-  "centos7"  => 112,
-  "centos6u4" => 113,
-  "debian7"  => 120,
-  "debian8"  => 121,
-  "opensuse11" => 130,
-  "opensuse12" => 131,
-  "ubuntu10" => 140,
-  "ubuntu12" => 141,
-  "ubuntu14" => 142,
-  "windows"  => 150,
-
-  "1.8.1"    => 51,
-  "2.0.1"    => 56,
-  "2.1.1"    => 61,
-  "2.2.0"    => 65,
-  "2.5.0"    => 70,
-  "2.5.1"    => 71,
-  "2.5.2"    => 72,
-  "3.0.0"    => 80,
-  "3.0.1"    => 81,
-  "3.0.2"    => 82,
-  "3.0.3"    => 83,
-  "3.1.0"    => 90,
-  "3.1.1"    => 91,
-  "3.1.2"    => 92,
-  "3.1.3"    => 93,
-  "3.1.4"    => 94,
-  "3.1.5"    => 95,
-  "3.1.6-testing"    => 96,
-  "4.0.0"    => 100,
-  "4.1.0"    => 110,
-  "4.1.1"    => 111,
-  "4.5.0"    => 150,
-  "4.5.0-testing" => 151,
-  "cbdev"    => 200,
-}
-vagrant_boxes = { # Vagrant Cloud base boxes for each operating system
-  "ubuntu10" => {"box_name" => "ubuntu-server-10044-x64-vbox4210",
-                 "box_url"  => "http://puppet-vagrant-boxes.puppetlabs.com/ubuntu-server-10044-x64-vbox4210.box"
-               },
-  "ubuntu12" => "hashicorp/precise64",
-  "ubuntu14" => "ubuntu/trusty64",
-  "debian7"  => "cargomedia/debian-7-amd64-default",
-  "centos5"  => {"box_name" => "centos5u8_x64",
-                 "box_url"  => "https://dl.dropbox.com/u/17738575/CentOS-5.8-x86_64.box"
-               },
-  "centos6"  => {"box_name" => "puppetlabs/centos-6.6-64-puppet",
-                 "box_version" => "1.0.1"
-                },
-  "centos6u4" => {"box_name" => "hansode/centos-6.4-x86_64",
-                  "box_version" => "0.2.0"
-                 },
-  "centos7"  => { "box_name" => "puppetlabs/centos-7.0-64-puppet",
-                  "box_version" => "1.0.1"
-                },
-  "windows"  => "emyl/win2008r2",
-  "opensuse11"  => "minesense/opensuse11.1",
-  "opensuse12"   => {"box_name" => "opensuse-12.3-64",
-                 "box_url" => "http://sourceforge.net/projects/opensusevagrant/files/12.3/opensuse-12.3-64.box/download",
-                },
-  "debian8"  => "lazyfrosch/debian-8-jessie-amd64-puppet",
-}
 
 # Collect the names of the working directory and its parent (os and cb version)
-operating_system = File.basename(Dir.getwd)
-version  ||= File.basename(File.expand_path('..'))
+OPERATING_SYSTEM = File.basename(Dir.getwd)
+VERSION  = File.basename(File.expand_path('..'))
 
-# Couchbase Server Version download links
-couchbase_releases = "http://packages.couchbase.com/releases"
-latest_builds = "http://latestbuilds.hq.couchbase.com"
-sherlock_builds = "#{latest_builds}/couchbase-server/sherlock"
-watson_build_num= "2601"
-watson_builds =  "https://s3.amazonaws.com/cb-support/watson-#{watson_build_num}"
-couchbase_download_links = {
-  "1.8.1" => "#{couchbase_releases}/#{version}/couchbase-server-enterprise_x86_64_#{version}",
-  "2.0.1" => "#{couchbase_releases}/#{version}/couchbase-server-enterprise_x86_64_#{version}",
-  "2.1.1" => "#{couchbase_releases}/#{version}/couchbase-server-enterprise_x86_64_#{version}",
-  "2.2.0" => "#{couchbase_releases}/#{version}/couchbase-server-enterprise_#{version}_x86_64",
-  "2.5.0" => {
-              "centos5"  => "#{couchbase_releases}/#{version}/couchbase-server-enterprise_#{version}_x86_64_openssl098",
-              "centos6"  => "#{couchbase_releases}/#{version}/couchbase-server-enterprise_#{version}_x86_64",
-              "ubuntu10" => "#{couchbase_releases}/#{version}/couchbase-server-enterprise_#{version}_x86_64_openssl098",
-              "ubuntu12" => "#{couchbase_releases}/#{version}/couchbase-server-enterprise_#{version}_x86_64",
-  },
-  "2.5.1" => {
-              "centos5"  => "#{couchbase_releases}/#{version}/couchbase-server-enterprise_#{version}_x86_64_openssl098",
-              "centos6"  => "#{couchbase_releases}/#{version}/couchbase-server-enterprise_#{version}_x86_64",
-              "ubuntu10" => "#{couchbase_releases}/#{version}/couchbase-server-enterprise_#{version}_x86_64_openssl098",
-              "ubuntu12" => "#{couchbase_releases}/#{version}/couchbase-server-enterprise_#{version}_x86_64",
-  },
-  "2.5.2" => {
-              "centos5"  => "#{couchbase_releases}/#{version}/couchbase-server-enterprise_#{version}_x86_64_openssl098",
-              "centos6"  => "#{couchbase_releases}/#{version}/couchbase-server-enterprise_#{version}_x86_64",
-              "ubuntu10" => "#{couchbase_releases}/#{version}/couchbase-server-enterprise_#{version}_x86_64_openssl098",
-              "ubuntu12" => "#{couchbase_releases}/#{version}/couchbase-server-enterprise_#{version}_x86_64",
-  },
-  "3.1.6-testing" => {
-              "centos6"    => "#{latest_builds}/couchbase-server-enterprise_centos6_x86_64_3.1.6-1895-rel",
-              "debian7"    => "#{latest_builds}/couchbase-server-enterprise_debian7_x86_64_3.1.6-1895-rel",
-              "opensuse11" => "#{latest_builds}/couchbase-server-enterprise_suse11_x86_64_3.1.6-1895-rel",
-              "ubuntu12"   => "#{latest_builds}/couchbase-server-enterprise_ubuntu_1204_x86_64_3.1.6-1895-rel",
-  },
-  "4.5.0-testing" => {
-              "centos6"    => "#{watson_builds}/couchbase-server-enterprise-4.5.0-#{watson_build_num}-centos6.x86_64",
-              "centos7"    => "#{watson_builds}/couchbase-server-enterprise-4.5.0-#{watson_build_num}-centos7.x86_64",
-              "debian7"    => "#{watson_builds}/couchbase-server-enterprise_4.5.0-#{watson_build_num}-debian7_amd64",
-              "debian8"    => "#{watson_builds}/couchbase-server-enterprise_4.5.0-#{watson_build_num}-debian8_amd64",
-              "opensuse11" => "#{watson_builds}/couchbase-server-enterprise-4.5.0-#{watson_build_num}-suse11.x86_64",
-              "opensuse12" => "#{watson_builds}/couchbase-server-enterprise-4.5.0-#{watson_build_num}-suse11.x86_64",
-              "ubuntu12"   => "#{watson_builds}/couchbase-server-enterprise_4.5.0-#{watson_build_num}-ubuntu12.04_amd64",
-              "ubuntu14"   => "#{watson_builds}/couchbase-server-enterprise_4.5.0-#{watson_build_num}-ubuntu14.04_amd64",
-  },
-  "centos6"    => "#{couchbase_releases}/#{version}/couchbase-server-enterprise-#{version}-centos6.x86_64",
-  "centos7"    => "#{couchbase_releases}/#{version}/couchbase-server-enterprise-#{version}-centos7.x86_64",
-  "debian7"    => "#{couchbase_releases}/#{version}/couchbase-server-enterprise_#{version}-debian7_amd64",
-  "debian8"    => "#{couchbase_releases}/#{version}/couchbase-server-enterprise_#{version}-debian7_amd64",
-  "opensuse11" => "#{couchbase_releases}/#{version}/couchbase-server-enterprise-#{version}-suse11.x86_64",
-  "opensuse12" => "#{couchbase_releases}/#{version}/couchbase-server-enterprise-#{version}-suse11.x86_64",
-  "ubuntu12"   => "#{couchbase_releases}/#{version}/couchbase-server-enterprise_#{version}-ubuntu12.04_amd64",
-  "ubuntu14"   => "#{couchbase_releases}/#{version}/couchbase-server-enterprise_#{version}-ubuntu14.04_amd64",
-}
-
-default_number_of_nodes = 4
-default_RAM_in_MB = 1024
-default_number_of_cpus = 1
-
-## Edit these to allow other machines in your network to access the VMs
-
-# Set to true to activate non-host access
-#  make sure no one else will be impacted by this, as VMs will have forced ip that could collide
-#  (typically you should be close to alone on the LAN, with a few machines, ie at home)
-# alternatively set use_dhcp to true to avoid this (at the cost of not knowing the IP in advance)
-public_lan = false
-use_dhcp = false
-
-# Name of the host endpoint to serve as bridge to local network
-#  (if not found vagrant will ask the user for each node)
-default_bridge = "wlan0"
-
-# Base for IP in public network. %d replaced by node number, eg "192.168.1.10%d" to get 101, 102, ...
-#  (once again, be careful of potential ip collisions!)
-public_ip_base = "192.168.1.10%d"
-
+# Variable declarations are in this file
+load '../../settings.rb'
 
 ### DO NOT EDIT BELOW THIS LINE
 
@@ -157,20 +17,20 @@ unless ENV['VAGRANT_NODES'].nil? || ENV['VAGRANT_NODES'] == 0
   num_nodes = ENV['VAGRANT_NODES'].to_i
 else
   if num_nodes.nil?
-    num_nodes = default_number_of_nodes
+    num_nodes = DEFAULT_NUMBER_OF_NODES
   end
 end
 
 unless ENV['VAGRANT_CPUS'].nil? || ENV['VAGRANT_CPUS'] == 0
   num_cpus = ENV['VAGRANT_CPUS'].to_i
 else
-  num_cpus = default_number_of_cpus
+  num_cpus = DEFAULT_NUMBER_OF_CPUS
 end
 
 unless ENV['VAGRANT_RAM'].nil? || ENV['VAGRANT_RAM'] == 0
   ram_in_MB = ENV['VAGRANT_RAM'].to_i
 else
-  ram_in_MB = default_RAM_in_MB
+  ram_in_MB = DEFAULT_RAM_IN_MB
 end
 
 unless ENV['VAGRANT_VPN'].nil?
@@ -180,26 +40,26 @@ else
 end
 
 # Check to see if a custom download location has been given, if not use a default value (2.5.0 style)
-if couchbase_download_links.has_key?(version)
-  if couchbase_download_links[version].is_a?(String)
-    url = couchbase_download_links[version]
-  elsif couchbase_download_links[version].has_key?(operating_system)
-    url = couchbase_download_links[version][operating_system]
+if COUCHBASE_DOWNLOAD_LINKS.has_key?(VERSION)
+  if COUCHBASE_DOWNLOAD_LINKS[VERSION].is_a?(String)
+    url = COUCHBASE_DOWNLOAD_LINKS[VERSION]
+  elsif COUCHBASE_DOWNLOAD_LINKS[VERSION].has_key?(OPERATING_SYSTEM)
+    url = COUCHBASE_DOWNLOAD_LINKS[VERSION][OPERATING_SYSTEM]
   end
-elsif couchbase_download_links.has_key?(operating_system)
-  url = couchbase_download_links[operating_system]
+elsif COUCHBASE_DOWNLOAD_LINKS.has_key?(OPERATING_SYSTEM)
+  url = COUCHBASE_DOWNLOAD_LINKS[OPERATING_SYSTEM]
 end
-url ||= "#{couchbase_releases}/#{version}/couchbase-server-enterprise_#{version}_x86_64"
+url ||= COUCHBASE_DOWNLOAD_LINKS['generic']
 
 puppet_location ||= "../.."
 
 # Check to see if a custom ip address has been given, if not generate one
 if (defined?(ip)).nil?
-  ip_address = "10." + String(ip_addresses[operating_system]) + "." + String(ip_addresses[version]) + ".10%d"
+  ip_address = "10." + String(IP_ADDRESSES[OPERATING_SYSTEM]) + "." + String(IP_ADDRESSES[VERSION]) + ".10%d"
 end
 
 # Generate a hostname template
-hostname = "#{version.gsub '.', ''}-#{operating_system}.vagrants"
+hostname = "#{VERSION.gsub '.', ''}-#{OPERATING_SYSTEM}.vagrants"
 if hostname =~ /^[0-9]/
   hostname.prepend("cb")
 end
@@ -207,7 +67,7 @@ hostname.prepend("node%d-")
 
 # Check to see if the vagrant command given was 'up', if so print a handy dialogue
 if ARGV[0] == "up" && !ARGV[1]
-  puts "\e[32m=== Upping #{num_nodes} node(s) on #{operating_system} and cb version #{version} ==="
+  puts "\e[32m=== Upping #{num_nodes} node(s) on #{OPERATING_SYSTEM} and cb version #{VERSION} ==="
 end
 
 ### Start the vagrant configuration ###
@@ -231,30 +91,30 @@ Vagrant.configure("2") do |config|
   config.vm.synced_folder ENV['HOME'], "/vmhost_home/"
 
   # Define the vagrant box download location
-  if !(vagrant_boxes[operating_system]["box_url"].nil?)
-    config.vm.box_url = vagrant_boxes[operating_system]["box_url"]
+  if !(VAGRANT_BOXES[OPERATING_SYSTEM]["box_url"].nil?)
+    config.vm.box_url = VAGRANT_BOXES[OPERATING_SYSTEM]["box_url"]
   end
 
   # Define the vagrant box name
-  if !(vagrant_boxes[operating_system]["box_name"].nil?)
-    box_name = vagrant_boxes[operating_system]["box_name"]
+  if !(VAGRANT_BOXES[OPERATING_SYSTEM]["box_name"].nil?)
+    box_name = VAGRANT_BOXES[OPERATING_SYSTEM]["box_name"]
   else
-    box_name = vagrant_boxes[operating_system]
+    box_name = VAGRANT_BOXES[OPERATING_SYSTEM]
   end
 
   # Define the box version if specified - default to most recent
-  if !(vagrant_boxes[operating_system]["box_version"].nil?)
-    box_version = vagrant_boxes[operating_system]["box_version"]
+  if !(VAGRANT_BOXES[OPERATING_SYSTEM]["box_version"].nil?)
+    boc_version = VAGRANT_BOXES[OPERATING_SYSTEM]["boc_version"]
   end
 
   # Check to see if the VM is not running Windows and provision with puppet
-  if !(operating_system.include?("win"))
+  if !(OPERATING_SYSTEM.include?("win"))
     # Provision the server itself with puppet
     config.vm.provision "puppet" do |puppet|
       puppet.manifests_path = puppet_location # Define a custom location and name for the puppet file
       puppet.manifest_file = "puppet.pp"
       puppet.facter = { # Pass variables to puppet
-        "version" => version, # Couchbase Server version
+        "version" => VERSION, # Couchbase Server version
         "url" => url, # Couchbase download location
       }
     end
@@ -264,19 +124,19 @@ Vagrant.configure("2") do |config|
   1.upto(num_nodes) do |num|
     config.vm.define "node#{num}" do |node|
       node.vm.box = box_name
-      if !(box_version.nil?)
-        node.vm.box_version = box_version
+      if !(boc_version.nil?)
+        node.vm.boc_version = boc_version
       end
       if Vagrant.has_plugin?("vagrant-cachier")
         # Configure cached packages to be shared between instances of the same base box.
         config.cache.scope = :box
       end
-      if public_lan && use_dhcp
-        node.vm.network :public_network, :bridge => default_bridge
+      if PUBLIC_LAN && USE_DHCP
+        node.vm.network :public_network, :bridge => DEFAULT_BRIDGE
         puts "Public LAN ip obtained via DHCP, find it by connecting to the node: vagrant ssh node#{num}"
-      elsif public_lan
-       node.vm.network :public_network, :bridge => default_bridge, :ip =>  public_ip_base % num
-       puts "Public LAN ip : #{public_ip_base % num}"
+      elsif PUBLIC_LAN
+       node.vm.network :public_network, :bridge => DEFAULT_BRIDGE, :ip =>  PUBLIC_IP_BASE % num
+       puts "Public LAN ip : #{PUBLIC_IP_BASE % num}"
       else
         node.vm.network :private_network, :ip => ip_address % num
         if Vagrant.has_plugin?("landrush")
@@ -287,8 +147,8 @@ Vagrant.configure("2") do |config|
       end
       node.vm.hostname = hostname % num
       node.vm.provider "virtualbox" do |v|
-        v.name = "Couchbase Server #{version} #{operating_system.gsub '/', '_'} Node #{num}"
-        if(operating_system.include?("win")) # If the VM is running Windows it will start with a GUI
+        v.name = "Couchbase Server #{VERSION} #{OPERATING_SYSTEM.gsub '/', '_'} Node #{num}"
+        if(OPERATING_SYSTEM.include?("win")) # If the VM is running Windows it will start with a GUI
           v.gui = true
         end
       end
@@ -304,10 +164,10 @@ Vagrant.configure("2") do |config|
   end
 
   if ARGV[0] == "up" && !ARGV[1]
-    if public_lan && use_dhcp
+    if PUBLIC_LAN && USE_DHCP
       puts "\e[32m=== Upping #{num_nodes} node(s) on public LAN via DHCP ==="
-    elsif public_lan
-      puts "\e[32m=== Upping #{num_nodes} node(s) on public LAN IPs #{public_ip_base.sub('%d','')}{1..#{num_nodes}} ==="
+    elsif PUBLIC_LAN
+      puts "\e[32m=== Upping #{num_nodes} node(s) on public LAN IPs #{PUBLIC_IP_BASE.sub('%d','')}{1..#{num_nodes}} ==="
     else
       puts "\e[32m=== Upping #{num_nodes} node(s) on IPs #{ip_address.sub('%d','')}{1..#{num_nodes}} ==="
     end

--- a/settings.rb
+++ b/settings.rb
@@ -1,0 +1,147 @@
+### Variable declarations - FEEL FREE TO EDIT THESE ###
+DEFAULT_NUMBER_OF_NODES = 4
+DEFAULT_RAM_IN_MB = 1024
+DEFAULT_NUMBER_OF_CPUS = 1
+
+
+### Edit these to allow other machines in your network to access the VMs
+
+# Set to true to activate non-host access
+#  make sure no one else will be impacted by this, as VMs will have forced ip that could collide
+#  (typically you should be close to alone on the LAN, with a few machines, ie at home)
+# alternatively set use_dhcp to true to avoid this (at the cost of not knowing the IP in advance)
+PUBLIC_LAN = false
+USE_DHCP = false
+
+# Name of the host endpoint to serve as bridge to local network
+#  (if not found vagrant will ask the user for each node)
+DEFAULT_BRIDGE = "wlan0"
+
+# Base for IP in public network. %d replaced by node number, eg "192.168.1.10%d" to get 101, 102, ...
+#  (once again, be careful of potential ip collisions!)
+PUBLIC_IP_BASE = "192.168.1.10%d"
+
+
+### These settings should only be changed when adding or removing certain versions
+IP_ADDRESSES = {
+  "centos5"  => 110,
+  "centos6"  => 111,
+  "centos7"  => 112,
+  "centos6u4" => 113,
+  "debian7"  => 120,
+  "debian8"  => 121,
+  "opensuse11" => 130,
+  "opensuse12" => 131,
+  "ubuntu10" => 140,
+  "ubuntu12" => 141,
+  "ubuntu14" => 142,
+  "windows"  => 150,
+
+  "1.8.1"    => 51,
+  "2.0.1"    => 56,
+  "2.1.1"    => 61,
+  "2.2.0"    => 65,
+  "2.5.0"    => 70,
+  "2.5.1"    => 71,
+  "2.5.2"    => 72,
+  "3.0.0"    => 80,
+  "3.0.1"    => 81,
+  "3.0.2"    => 82,
+  "3.0.3"    => 83,
+  "3.1.0"    => 90,
+  "3.1.1"    => 91,
+  "3.1.2"    => 92,
+  "3.1.3"    => 93,
+  "3.1.4"    => 94,
+  "3.1.5"    => 95,
+  "3.1.6-testing"    => 96,
+  "4.0.0"    => 100,
+  "4.1.0"    => 110,
+  "4.1.1"    => 111,
+  "4.5.0"    => 150,
+  "4.5.0-testing" => 151,
+  "cbdev"    => 200,
+}
+
+VAGRANT_BOXES = {
+  "ubuntu10" => {"box_name" => "ubuntu-server-10044-x64-vbox4210",
+                 "box_url"  => "http://puppet-vagrant-boxes.puppetlabs.com/ubuntu-server-10044-x64-vbox4210.box"
+               },
+  "ubuntu12" => "hashicorp/precise64",
+  "ubuntu14" => "ubuntu/trusty64",
+  "debian7"  => "cargomedia/debian-7-amd64-default",
+  "centos5"  => {"box_name" => "centos5u8_x64",
+                 "box_url"  => "https://dl.dropbox.com/u/17738575/CentOS-5.8-x86_64.box"
+               },
+  "centos6"  => {"box_name" => "puppetlabs/centos-6.6-64-puppet",
+                 "box_VERSION" => "1.0.1"
+                },
+  "centos6u4" => {"box_name" => "hansode/centos-6.4-x86_64",
+                  "box_VERSION" => "0.2.0"
+                 },
+  "centos7"  => { "box_name" => "puppetlabs/centos-7.0-64-puppet",
+                  "box_VERSION" => "1.0.1"
+                },
+  "windows"  => "emyl/win2008r2",
+  "opensuse11"  => "minesense/opensuse11.1",
+  "opensuse12"   => {"box_name" => "opensuse-12.3-64",
+                 "box_url" => "http://sourceforge.net/projects/opensusevagrant/files/12.3/opensuse-12.3-64.box/download",
+                },
+  "debian8"  => "lazyfrosch/debian-8-jessie-amd64-puppet",
+}
+
+# Couchbase Server Version download links
+COUCHBASE_RELEASES = "http://packages.couchbase.com/releases"
+LATEST_BUILDS = "http://latestbuilds.hq.couchbase.com"
+SHERLOCK_BUILDS = "#{LATEST_BUILDS}/couchbase-server/sherlock"
+WATSON_BUILD_NUM = "2601"
+WATSON_BUILDS =  "https://s3.amazonaws.com/cb-support/watson-#{WATSON_BUILD_NUM}"
+COUCHBASE_DOWNLOAD_LINKS = {
+  "generic" => "#{COUCHBASE_RELEASES}/#{VERSION}/couchbase-server-enterprise_#{VERSION}_x86_64",
+  "1.8.1" => "#{COUCHBASE_RELEASES}/#{VERSION}/couchbase-server-enterprise_x86_64_#{VERSION}",
+  "2.0.1" => "#{COUCHBASE_RELEASES}/#{VERSION}/couchbase-server-enterprise_x86_64_#{VERSION}",
+  "2.1.1" => "#{COUCHBASE_RELEASES}/#{VERSION}/couchbase-server-enterprise_x86_64_#{VERSION}",
+  "2.2.0" => "#{COUCHBASE_RELEASES}/#{VERSION}/couchbase-server-enterprise_#{VERSION}_x86_64",
+  "2.5.0" => {
+              "centos5"  => "#{COUCHBASE_RELEASES}/#{VERSION}/couchbase-server-enterprise_#{VERSION}_x86_64_openssl098",
+              "centos6"  => "#{COUCHBASE_RELEASES}/#{VERSION}/couchbase-server-enterprise_#{VERSION}_x86_64",
+              "ubuntu10" => "#{COUCHBASE_RELEASES}/#{VERSION}/couchbase-server-enterprise_#{VERSION}_x86_64_openssl098",
+              "ubuntu12" => "#{COUCHBASE_RELEASES}/#{VERSION}/couchbase-server-enterprise_#{VERSION}_x86_64",
+  },
+  "2.5.1" => {
+              "centos5"  => "#{COUCHBASE_RELEASES}/#{VERSION}/couchbase-server-enterprise_#{VERSION}_x86_64_openssl098",
+              "centos6"  => "#{COUCHBASE_RELEASES}/#{VERSION}/couchbase-server-enterprise_#{VERSION}_x86_64",
+              "ubuntu10" => "#{COUCHBASE_RELEASES}/#{VERSION}/couchbase-server-enterprise_#{VERSION}_x86_64_openssl098",
+              "ubuntu12" => "#{COUCHBASE_RELEASES}/#{VERSION}/couchbase-server-enterprise_#{VERSION}_x86_64",
+  },
+  "2.5.2" => {
+              "centos5"  => "#{COUCHBASE_RELEASES}/#{VERSION}/couchbase-server-enterprise_#{VERSION}_x86_64_openssl098",
+              "centos6"  => "#{COUCHBASE_RELEASES}/#{VERSION}/couchbase-server-enterprise_#{VERSION}_x86_64",
+              "ubuntu10" => "#{COUCHBASE_RELEASES}/#{VERSION}/couchbase-server-enterprise_#{VERSION}_x86_64_openssl098",
+              "ubuntu12" => "#{COUCHBASE_RELEASES}/#{VERSION}/couchbase-server-enterprise_#{VERSION}_x86_64",
+  },
+  "3.1.6-testing" => {
+              "centos6"    => "#{LATEST_BUILDS}/couchbase-server-enterprise_centos6_x86_64_3.1.6-1895-rel",
+              "debian7"    => "#{LATEST_BUILDS}/couchbase-server-enterprise_debian7_x86_64_3.1.6-1895-rel",
+              "opensuse11" => "#{LATEST_BUILDS}/couchbase-server-enterprise_suse11_x86_64_3.1.6-1895-rel",
+              "ubuntu12"   => "#{LATEST_BUILDS}/couchbase-server-enterprise_ubuntu_1204_x86_64_3.1.6-1895-rel",
+  },
+  "4.5.0-testing" => {
+              "centos6"    => "#{WATSON_BUILDS}/couchbase-server-enterprise-4.5.0-#{WATSON_BUILD_NUM}-centos6.x86_64",
+              "centos7"    => "#{WATSON_BUILDS}/couchbase-server-enterprise-4.5.0-#{WATSON_BUILD_NUM}-centos7.x86_64",
+              "debian7"    => "#{WATSON_BUILDS}/couchbase-server-enterprise_4.5.0-#{WATSON_BUILD_NUM}-debian7_amd64",
+              "debian8"    => "#{WATSON_BUILDS}/couchbase-server-enterprise_4.5.0-#{WATSON_BUILD_NUM}-debian8_amd64",
+              "opensuse11" => "#{WATSON_BUILDS}/couchbase-server-enterprise-4.5.0-#{WATSON_BUILD_NUM}-suse11.x86_64",
+              "opensuse12" => "#{WATSON_BUILDS}/couchbase-server-enterprise-4.5.0-#{WATSON_BUILD_NUM}-suse11.x86_64",
+              "ubuntu12"   => "#{WATSON_BUILDS}/couchbase-server-enterprise_4.5.0-#{WATSON_BUILD_NUM}-ubuntu12.04_amd64",
+              "ubuntu14"   => "#{WATSON_BUILDS}/couchbase-server-enterprise_4.5.0-#{WATSON_BUILD_NUM}-ubuntu14.04_amd64",
+  },
+  "centos6"    => "#{COUCHBASE_RELEASES}/#{VERSION}/couchbase-server-enterprise-#{VERSION}-centos6.x86_64",
+  "centos7"    => "#{COUCHBASE_RELEASES}/#{VERSION}/couchbase-server-enterprise-#{VERSION}-centos7.x86_64",
+  "debian7"    => "#{COUCHBASE_RELEASES}/#{VERSION}/couchbase-server-enterprise_#{VERSION}-debian7_amd64",
+  "debian8"    => "#{COUCHBASE_RELEASES}/#{VERSION}/couchbase-server-enterprise_#{VERSION}-debian7_amd64",
+  "opensuse11" => "#{COUCHBASE_RELEASES}/#{VERSION}/couchbase-server-enterprise-#{VERSION}-suse11.x86_64",
+  "opensuse12" => "#{COUCHBASE_RELEASES}/#{VERSION}/couchbase-server-enterprise-#{VERSION}-suse11.x86_64",
+  "ubuntu12"   => "#{COUCHBASE_RELEASES}/#{VERSION}/couchbase-server-enterprise_#{VERSION}-ubuntu12.04_amd64",
+  "ubuntu14"   => "#{COUCHBASE_RELEASES}/#{VERSION}/couchbase-server-enterprise_#{VERSION}-ubuntu14.04_amd64",
+}


### PR DESCRIPTION
Editable settings are now contained within `settings.rb`. This is loaded near the start of `Top_Level_Vagrantfile`, but after `OPERATING_SYSTEM` and `VERSION` are evaluated as `VERSION` is required by some of the URLs. All variables have been changed to global constants as they are not expected to be changed at runtime.
