### PR TITLE
Add Centos7u2

### DIFF
--- a/5.0.0-beta/centos7u2/Vagrantfile
+++ b/5.0.0-beta/centos7u2/Vagrantfile
@@ -1,0 +1,4 @@
+# Read and execute the top level Vagrantfile
+Dir.chdir File.dirname(__FILE__)
+external = File.read '../../Top_Level_Vagrantfile'
+eval external

--- a/5.0.0-testing/centos7u2/Vagrantfile
+++ b/5.0.0-testing/centos7u2/Vagrantfile
@@ -1,0 +1,4 @@
+# Read and execute the top level Vagrantfile
+Dir.chdir File.dirname(__FILE__)
+external = File.read '../../Top_Level_Vagrantfile'
+eval external

--- a/Top_Level_Vagrantfile
+++ b/Top_Level_Vagrantfile
@@ -7,6 +7,7 @@ ip_addresses = { # Values for both OS's and Couchbase versions that are cat'd to
   "centos5"  => 110,
   "centos6"  => 111,
   "centos7"  => 112,
+  "centos7u2"  => 114,
   "centos6u4" => 113,
   "debian7"  => 120,
   "debian8"  => 121,
@@ -81,6 +82,10 @@ vagrant_boxes = { # Vagrant Cloud base boxes for each operating system
   "centos7"  => { "box_name" => "puppetlabs/centos-7.0-64-puppet",
                   "box_version" => "1.0.1"
                 },
+  "centos7u2"  => { "box_name" => "puppetlabs/centos-7.2-64-puppet",
+                  "box_version" => "1.0.1"
+                },
+
   "windows"  => "emyl/win2008r2",
   "opensuse11"  => "minesense/opensuse11.1",
   "opensuse12"   => {"box_name" => "opensuse-12.3-64",


### PR DESCRIPTION
Create centos7u2 directories in 5.0.0beta and 5.0.0testing.
The box used here matches one that QE have been testing
with.

> cat /etc/redhat-release
CentOS Linux release 7.2.1511 (Core)