### PR TITLE
Do apt-get update before installing puppet

### DIFF
--- a/Top_Level_Vagrantfile
+++ b/Top_Level_Vagrantfile
@@ -304,6 +304,7 @@ Vagrant.configure("2") do |config|
   # Check to see if the VM is not running Windows and provision with puppet
   if !(operating_system.include?("win"))
     if (operating_system.include?("ubuntu16"))
+      config.vm.provision "shell", inline: "apt-get update"
       config.vm.provision "shell", inline: "apt-get install -y puppet"
     end
     # Provision the server itself with puppet


### PR DESCRIPTION
Get an error with Ubuntu16 as the package db is empty,
    node1: Reading state information...
    node1: E
    node1: :
    node1: Unable to locate package puppet

This change updates the DB before attempting to install the puppet package. 