### PR TITLE
CBSP-1364: Adds Couchbase Server 5.5.0-beta

### DIFF
--- a/5.5.0-beta/centos6/Vagrantfile
+++ b/5.5.0-beta/centos6/Vagrantfile
@@ -1,0 +1,6 @@
+# 5.5.0-beta requires 2.5GB to startup (sadpanda)
+ram_in_MB = 2560
+# Read and execute the top level Vagrantfile
+Dir.chdir File.dirname(__FILE__)
+external = File.read '../../Top_Level_Vagrantfile'
+eval external

--- a/5.5.0-beta/centos7/Vagrantfile
+++ b/5.5.0-beta/centos7/Vagrantfile
@@ -1,0 +1,6 @@
+# 5.5.0-beta requires 2.5GB to startup (sadpanda)
+ram_in_MB = 2560
+# Read and execute the top level Vagrantfile
+Dir.chdir File.dirname(__FILE__)
+external = File.read '../../Top_Level_Vagrantfile'
+eval external

--- a/5.5.0-beta/debian8/Vagrantfile
+++ b/5.5.0-beta/debian8/Vagrantfile
@@ -1,0 +1,6 @@
+# 5.5.0-beta requires 2.5GB to startup (sadpanda)
+ram_in_MB = 2560
+# Read and execute the top level Vagrantfile
+Dir.chdir File.dirname(__FILE__)
+external = File.read '../../Top_Level_Vagrantfile'
+eval external

--- a/5.5.0-beta/opensuse11/Vagrantfile
+++ b/5.5.0-beta/opensuse11/Vagrantfile
@@ -1,0 +1,6 @@
+# 5.5.0-beta requires 2.5GB to startup (sadpanda)
+ram_in_MB = 2560
+# Read and execute the top level Vagrantfile
+Dir.chdir File.dirname(__FILE__)
+external = File.read '../../Top_Level_Vagrantfile'
+eval external

--- a/5.5.0-beta/opensuse12/Vagrantfile
+++ b/5.5.0-beta/opensuse12/Vagrantfile
@@ -1,0 +1,6 @@
+# 5.5.0-beta requires 2.5GB to startup (sadpanda)
+ram_in_MB = 2560
+# Read and execute the top level Vagrantfile
+Dir.chdir File.dirname(__FILE__)
+external = File.read '../../Top_Level_Vagrantfile'
+eval external

--- a/5.5.0-beta/ubuntu14/Vagrantfile
+++ b/5.5.0-beta/ubuntu14/Vagrantfile
@@ -1,0 +1,6 @@
+# 5.5.0-beta requires 2.5GB to startup (sadpanda)
+ram_in_MB = 2560
+# Read and execute the top level Vagrantfile
+Dir.chdir File.dirname(__FILE__)
+external = File.read '../../Top_Level_Vagrantfile'
+eval external

--- a/5.5.0-beta/ubuntu16/Vagrantfile
+++ b/5.5.0-beta/ubuntu16/Vagrantfile
@@ -1,0 +1,6 @@
+# 5.5.0-beta requires 2.5GB to startup (sadpanda)
+ram_in_MB = 2560
+# Read and execute the top level Vagrantfile
+Dir.chdir File.dirname(__FILE__)
+external = File.read '../../Top_Level_Vagrantfile'
+eval external

--- a/Top_Level_Vagrantfile
+++ b/Top_Level_Vagrantfile
@@ -61,7 +61,8 @@ ip_addresses = { # Values for both OS's and Couchbase versions that are cat'd to
   "5.1.0" => 175,
   "spock-testing" => 176,
 
-  "vulcan-testing" => 180,
+  "5.5.0-beta" => 180,
+  "vulcan-testing" => 181,
 
   "cbdev"    => 200,
   "perfrunner" => 210,


### PR DESCRIPTION
Note: this requires a machine with 2.5GB RAM, fixed in MB-29290