### PR TITLE
CBSP-2466: Fix SFTP changes for CentOS

### DIFF
--- a/puppet.pp
+++ b/puppet.pp
@@ -71,11 +71,11 @@ elsif $operatingsystem == 'CentOS'{
   notice("Fixing SFTP for ${operatingsystem} ${operatingsystemrelease}")
   exec { 'Fix SFTP':
          command => "sed -i 's|/usr/lib/openssh/sftp-server|internal-sftp|g' /etc/ssh/sshd_config",
-         path => "/usr/bin"
+         path => "/bin"
   }
   exec { "service sshd reload":
          require => Exec['Fix SFTP'],
-         path => "/usr/sbin"
+         path => "/sbin"
   }
 
   # Install pkgconfig (not all CentOS base boxes have it).


### PR DESCRIPTION
The UsrMove project (https://fedoraproject.org/wiki/Features/UsrMove)
has seen /bin, /sbin/, etc. merge into /usr/, then become symlinks to
those directories.

This means that CentOS 6 and 7 both have a /bin/sed and an /sbin/service,
but only CentOS 7 has the equivalents under /usr, so this change will
suffice for now.