### PR TITLE
Update Top_Level_Vagrantfile's MH version

### DIFF
--- a/Top_Level_Vagrantfile
+++ b/Top_Level_Vagrantfile
@@ -127,7 +127,7 @@ vulcan_build_num= "4302"
 vulcan_builds =  "#{latest_builds}/vulcan/#{vulcan_build_num}"
 alice_build_num= "2037"
 alice_builds =  "#{latest_builds}/alice/#{alice_build_num}"
-mad_hatter_build_num= "3821"
+mad_hatter_build_num= "4380"
 mad_hatter_builds =  "#{latest_builds}/mad-hatter/#{mad_hatter_build_num}"
 
 couchbase_download_links = {


### PR DESCRIPTION
Updating the default mad_hatter_build_num to 4380 (MH Beta2) to avoid incompatibilities such as MB-36476