### PR TITLE
CBSP-3472: Added a workable debian9 box

### DIFF
--- a/Top_Level_Vagrantfile
+++ b/Top_Level_Vagrantfile
@@ -11,6 +11,7 @@ ip_addresses = { # Values for both OS's and Couchbase versions that are cat'd to
   "centos6u4" => 113,
   "debian7"  => 120,
   "debian8"  => 121,
+  "debian9"  => 122,
   "opensuse11" => 130,
   "opensuse12" => 131,
   "ubuntu10" => 140,
@@ -126,6 +127,7 @@ vagrant_boxes = { # Vagrant Cloud base boxes for each operating system
                  "box_url" => "http://sourceforge.net/projects/opensusevagrant/files/12.3/opensuse-12.3-64.box/download",
                 },
   "debian8"  => "lazyfrosch/debian-8-jessie-amd64-puppet",
+  "debian9"  => "generic/debian9",
 }
 
 # Collect the names of the working directory and its parent (os and cb version)
@@ -383,7 +385,7 @@ Vagrant.configure("2") do |config|
   end
 
   # ubuntu1804 and 2004 boxes do not have puppet installed:
-  if(operating_system.include?("ubuntu18") || operating_system.include?("ubuntu20"))
+  if(operating_system.include?("ubuntu18") || operating_system.include?("ubuntu20") || operating_system.include?("debian9"))
     config.vm.provision "shell", inline: "(apt update && apt install -y puppet) &> /dev/null"
   end
 

--- a/puppet.pp
+++ b/puppet.pp
@@ -97,7 +97,10 @@ package { "libssl":
             '18.04' => "libssl1.0.0",
             '20.04' => "libssl1.1"},
         'CentOS' => "openssl098e",
-        'Debian' => "libssl1.0.0",
+        'Debian' => $::operatingsystemmajrelease ? {
+	    '7' => "libssl1.0.0",
+	    '8' => "libssl1.0.0",
+	    '9' => "libssl1.1"},
         'OpenSuSE' => "openssl",
     },
     ensure => present,


### PR DESCRIPTION
Have added a working Debian 9 box so Vagrant is now able to create Couchbase Server clusters on this platform.