### PR TITLE
CBSP-3474: Added debain10 and the relevant releases for debian10

### DIFF
--- a/6.6.0/debian10/Vagrantfile
+++ b/6.6.0/debian10/Vagrantfile
@@ -1,0 +1,4 @@
+# Read and execute the top level Vagrantfile
+Dir.chdir File.dirname(__FILE__)
+external = File.read '../../Top_Level_Vagrantfile'
+eval external


### PR DESCRIPTION
Added a Vagrant box for Debian 10, and the **folders** and **Vagrantfile** files for debian10 deployments to work. 