### PR TITLE
CBSP-4124: Add vagrants for 6.6.4, 6.6.5, 7.0.3

### DIFF
--- a/6.6.4/centos7/Vagrantfile
+++ b/6.6.4/centos7/Vagrantfile
@@ -1,0 +1,4 @@
+# Read and execute the top level Vagrantfile
+Dir.chdir File.dirname(__FILE__)
+external = File.read '../../Top_Level_Vagrantfile'
+eval external

--- a/6.6.4/centos8/Vagrantfile
+++ b/6.6.4/centos8/Vagrantfile
@@ -1,0 +1,4 @@
+# Read and execute the top level Vagrantfile
+Dir.chdir File.dirname(__FILE__)
+external = File.read '../../Top_Level_Vagrantfile'
+eval external

--- a/6.6.4/debian10/Vagrantfile
+++ b/6.6.4/debian10/Vagrantfile
@@ -1,0 +1,4 @@
+# Read and execute the top level Vagrantfile
+Dir.chdir File.dirname(__FILE__)
+external = File.read '../../Top_Level_Vagrantfile'
+eval external

--- a/6.6.4/debian9/Vagrantfile
+++ b/6.6.4/debian9/Vagrantfile
@@ -1,0 +1,4 @@
+# Read and execute the top level Vagrantfile
+Dir.chdir File.dirname(__FILE__)
+external = File.read '../../Top_Level_Vagrantfile'
+eval external

--- a/6.6.4/opensuse12/Vagrantfile
+++ b/6.6.4/opensuse12/Vagrantfile
@@ -1,0 +1,4 @@
+# Read and execute the top level Vagrantfile
+Dir.chdir File.dirname(__FILE__)
+external = File.read '../../Top_Level_Vagrantfile'
+eval external

--- a/6.6.4/ubuntu16/Vagrantfile
+++ b/6.6.4/ubuntu16/Vagrantfile
@@ -1,0 +1,4 @@
+# Read and execute the top level Vagrantfile
+Dir.chdir File.dirname(__FILE__)
+external = File.read '../../Top_Level_Vagrantfile'
+eval external

--- a/6.6.4/ubuntu18/Vagrantfile
+++ b/6.6.4/ubuntu18/Vagrantfile
@@ -1,0 +1,4 @@
+# Read and execute the top level Vagrantfile
+Dir.chdir File.dirname(__FILE__)
+external = File.read '../../Top_Level_Vagrantfile'
+eval external

--- a/6.6.4/ubuntu20/Vagrantfile
+++ b/6.6.4/ubuntu20/Vagrantfile
@@ -1,0 +1,4 @@
+# Read and execute the top level Vagrantfile
+Dir.chdir File.dirname(__FILE__)
+external = File.read '../../Top_Level_Vagrantfile'
+eval external

--- a/6.6.5/centos7/Vagrantfile
+++ b/6.6.5/centos7/Vagrantfile
@@ -1,0 +1,4 @@
+# Read and execute the top level Vagrantfile
+Dir.chdir File.dirname(__FILE__)
+external = File.read '../../Top_Level_Vagrantfile'
+eval external

--- a/6.6.5/centos8/Vagrantfile
+++ b/6.6.5/centos8/Vagrantfile
@@ -1,0 +1,4 @@
+# Read and execute the top level Vagrantfile
+Dir.chdir File.dirname(__FILE__)
+external = File.read '../../Top_Level_Vagrantfile'
+eval external

--- a/6.6.5/debian10/Vagrantfile
+++ b/6.6.5/debian10/Vagrantfile
@@ -1,0 +1,4 @@
+# Read and execute the top level Vagrantfile
+Dir.chdir File.dirname(__FILE__)
+external = File.read '../../Top_Level_Vagrantfile'
+eval external

--- a/6.6.5/debian9/Vagrantfile
+++ b/6.6.5/debian9/Vagrantfile
@@ -1,0 +1,4 @@
+# Read and execute the top level Vagrantfile
+Dir.chdir File.dirname(__FILE__)
+external = File.read '../../Top_Level_Vagrantfile'
+eval external

--- a/6.6.5/opensuse12/Vagrantfile
+++ b/6.6.5/opensuse12/Vagrantfile
@@ -1,0 +1,4 @@
+# Read and execute the top level Vagrantfile
+Dir.chdir File.dirname(__FILE__)
+external = File.read '../../Top_Level_Vagrantfile'
+eval external

--- a/6.6.5/ubuntu16/Vagrantfile
+++ b/6.6.5/ubuntu16/Vagrantfile
@@ -1,0 +1,4 @@
+# Read and execute the top level Vagrantfile
+Dir.chdir File.dirname(__FILE__)
+external = File.read '../../Top_Level_Vagrantfile'
+eval external

--- a/6.6.5/ubuntu18/Vagrantfile
+++ b/6.6.5/ubuntu18/Vagrantfile
@@ -1,0 +1,4 @@
+# Read and execute the top level Vagrantfile
+Dir.chdir File.dirname(__FILE__)
+external = File.read '../../Top_Level_Vagrantfile'
+eval external

--- a/6.6.5/ubuntu20/Vagrantfile
+++ b/6.6.5/ubuntu20/Vagrantfile
@@ -1,0 +1,4 @@
+# Read and execute the top level Vagrantfile
+Dir.chdir File.dirname(__FILE__)
+external = File.read '../../Top_Level_Vagrantfile'
+eval external

--- a/7.0.3/centos7/Vagrantfile
+++ b/7.0.3/centos7/Vagrantfile
@@ -1,0 +1,4 @@
+# Read and execute the top level Vagrantfile
+Dir.chdir File.dirname(__FILE__)
+external = File.read '../../Top_Level_Vagrantfile'
+eval external

--- a/7.0.3/centos8/Vagrantfile
+++ b/7.0.3/centos8/Vagrantfile
@@ -1,0 +1,4 @@
+# Read and execute the top level Vagrantfile
+Dir.chdir File.dirname(__FILE__)
+external = File.read '../../Top_Level_Vagrantfile'
+eval external

--- a/7.0.3/debian10/Vagrantfile
+++ b/7.0.3/debian10/Vagrantfile
@@ -1,0 +1,4 @@
+# Read and execute the top level Vagrantfile
+Dir.chdir File.dirname(__FILE__)
+external = File.read '../../Top_Level_Vagrantfile'
+eval external

--- a/7.0.3/debian9/Vagrantfile
+++ b/7.0.3/debian9/Vagrantfile
@@ -1,0 +1,4 @@
+# Read and execute the top level Vagrantfile
+Dir.chdir File.dirname(__FILE__)
+external = File.read '../../Top_Level_Vagrantfile'
+eval external

--- a/7.0.3/opensuse12/Vagrantfile
+++ b/7.0.3/opensuse12/Vagrantfile
@@ -1,0 +1,4 @@
+# Read and execute the top level Vagrantfile
+Dir.chdir File.dirname(__FILE__)
+external = File.read '../../Top_Level_Vagrantfile'
+eval external

--- a/7.0.3/ubuntu18/Vagrantfile
+++ b/7.0.3/ubuntu18/Vagrantfile
@@ -1,0 +1,4 @@
+# Read and execute the top level Vagrantfile
+Dir.chdir File.dirname(__FILE__)
+external = File.read '../../Top_Level_Vagrantfile'
+eval external

--- a/7.0.3/ubuntu20/Vagrantfile
+++ b/7.0.3/ubuntu20/Vagrantfile
@@ -1,0 +1,4 @@
+# Read and execute the top level Vagrantfile
+Dir.chdir File.dirname(__FILE__)
+external = File.read '../../Top_Level_Vagrantfile'
+eval external

--- a/Top_Level_Vagrantfile
+++ b/Top_Level_Vagrantfile
@@ -98,14 +98,17 @@ ip_addresses = { # Values for both OS's and Couchbase versions that are cat'd to
   "6.6.1" => 206,
   "6.6.2" => 207,
   "6.6.3" => 208,
-  "mad-hatter-testing" => 209,
+  "6.6.4" => 209,
+  "6.6.5" => 210,
+  "mad-hatter-testing" => 211,
 
-  "7.0.0" => 210, 
-  "7.0.1" => 211, 
-  "7.0.2" => 212, 
-  "cheshire-cat-testing" => 213,
+  "7.0.0" => 220, 
+  "7.0.1" => 221, 
+  "7.0.2" => 222, 
+  "7.0.3" => 223,
+  "cheshire-cat-testing" => 224,
 
-  "neo-testing" => 220,
+  "neo-testing" => 230,
 }
 vagrant_boxes = { # Vagrant Cloud base boxes for each operating system
   "ubuntu10" => {"box_name" => "ubuntu-server-10044-x64-vbox4210",


### PR DESCRIPTION
Sanity-checked by spinning up a 6.6.5/centos7 and 7.0.3/centos7, both start up and install CB fine.