### PR TITLE
CBSP-4161: Add morpheus-testing

### DIFF
--- a/Top_Level_Vagrantfile
+++ b/Top_Level_Vagrantfile
@@ -14,6 +14,7 @@ ip_addresses = { # Values for both OS's and Couchbase versions that are cat'd to
   "debian8"  => 121,
   "debian9"  => 122,
   "debian10"  => 123,
+  "debian11" => 124,
   "opensuse11" => 130,
   "opensuse12" => 131,
   "ubuntu10" => 140,
@@ -109,6 +110,8 @@ ip_addresses = { # Values for both OS's and Couchbase versions that are cat'd to
   "cheshire-cat-testing" => 224,
 
   "neo-testing" => 230,
+
+  "morpheus-testing" => 240,
 }
 vagrant_boxes = { # Vagrant Cloud base boxes for each operating system
   "ubuntu10" => {"box_name" => "ubuntu-server-10044-x64-vbox4210",
@@ -119,6 +122,7 @@ vagrant_boxes = { # Vagrant Cloud base boxes for each operating system
   "ubuntu16" => "puppetlabs/ubuntu-16.04-64-puppet",
   "ubuntu18" => "generic/ubuntu1804",
   "ubuntu20" => "generic/ubuntu2004",
+#  "ubuntu22" => "generic/ubuntu2204", # TODO - ETA 2022-04-21, will be supported for Morpheus
   "debian7"  => "cargomedia/debian-7-amd64-default",
   "centos5"  => {"box_name" => "centos5u8_x64",
                  "box_url"  => "https://dl.dropbox.com/u/17738575/CentOS-5.8-x86_64.box"
@@ -139,9 +143,11 @@ vagrant_boxes = { # Vagrant Cloud base boxes for each operating system
   "opensuse12"   => {"box_name" => "opensuse-12.3-64",
                  "box_url" => "http://sourceforge.net/projects/opensusevagrant/files/12.3/opensuse-12.3-64.box/download",
                 },
+  "opensuse15" => "generic/opensuse15",
   "debian8"  => "lazyfrosch/debian-8-jessie-amd64-puppet",
   "debian9"  => "generic/debian9",
   "debian10" => "debian/contrib-buster64",
+  "debian11" => "debian/bullseye64",
 }
 
 # Collect the names of the working directory and its parent (os and cb version)
@@ -176,6 +182,8 @@ cheshire_cat_build_num= "4735"
 cheshire_cat_builds = "#{latest_builds}/cheshire-cat/#{cheshire_cat_build_num}"
 neo_build_num= "2179"
 neo_builds = "#{latest_builds}/neo/#{neo_build_num}"
+morpheus_build_num= "1055"
+morpheus_builds = "#{latest_builds}/morpheus/#{morpheus_build_num}"
 
 
 couchbase_download_links = {
@@ -267,6 +275,13 @@ couchbase_download_links = {
               "opensuse12" => "#{neo_builds}/couchbase-server-#{edition}-7.1.0-#{neo_build_num}-suse12.x86_64",
               "ubuntu18"   => "#{neo_builds}/couchbase-server-#{edition}_7.1.0-#{neo_build_num}-ubuntu18.04_amd64",
               "ubuntu20"   => "#{neo_builds}/couchbase-server-#{edition}_7.1.0-#{neo_build_num}-ubuntu20.04_amd64",
+  },
+  "morpheus-testing" => {
+              "debian10"   => "#{morpheus_builds}/couchbase-server-#{edition}_7.2.0-#{morpheus_build_num}-debian10_amd64",
+              "debian11"   => "#{morpheus_builds}/couchbase-server-#{edition}_7.2.0-#{morpheus_build_num}-debian11_amd64",
+              "ubuntu20"   => "#{morpheus_builds}/couchbase-server-#{edition}_7.2.0-#{morpheus_build_num}-ubuntu20.04_amd64",
+              "ubuntu22"   => "#{morpheus_builds}/couchbase-server-#{edition}_7.2.0-#{morpheus_build_num}-ubuntu20.04_amd64",
+              "opensuse12" => "#{morpheus_builds}/couchbase-server-#{edition}_7.2.0-#{morpheus_build_num}-suse12.x86_64",
   },
   "centos6"    => "#{couchbase_releases}/#{version}/couchbase-server-#{edition}-#{version}-centos6.x86_64",
   "centos7"    => "#{couchbase_releases}/#{version}/couchbase-server-#{edition}-#{version}-centos7.x86_64",
@@ -413,7 +428,7 @@ Vagrant.configure("2") do |config|
   end
 
   # ubuntu1804 and 2004 boxes do not have puppet installed:
-  if(operating_system.include?("ubuntu18") || operating_system.include?("ubuntu20") || operating_system.include?("debian9") || operating_system.include?("debian10"))
+  if(operating_system.include?("ubuntu18") || operating_system.include?("ubuntu20") || operating_system.include?("debian"))
     config.vm.provision "shell", inline: "(apt update && apt install -y puppet) &> /dev/null"
   end
 

--- a/morpheus-testing/debian10/Vagrantfile
+++ b/morpheus-testing/debian10/Vagrantfile
@@ -1,0 +1,4 @@
+# Read and execute the top level Vagrantfile
+Dir.chdir File.dirname(__FILE__)
+external = File.read '../../Top_Level_Vagrantfile'
+eval external

--- a/morpheus-testing/debian11/Vagrantfile
+++ b/morpheus-testing/debian11/Vagrantfile
@@ -1,0 +1,4 @@
+# Read and execute the top level Vagrantfile
+Dir.chdir File.dirname(__FILE__)
+external = File.read '../../Top_Level_Vagrantfile'
+eval external

--- a/morpheus-testing/opensuse12/Vagrantfile
+++ b/morpheus-testing/opensuse12/Vagrantfile
@@ -1,0 +1,4 @@
+# Read and execute the top level Vagrantfile
+Dir.chdir File.dirname(__FILE__)
+external = File.read '../../Top_Level_Vagrantfile'
+eval external

--- a/morpheus-testing/ubuntu20/Vagrantfile
+++ b/morpheus-testing/ubuntu20/Vagrantfile
@@ -1,0 +1,4 @@
+# Read and execute the top level Vagrantfile
+Dir.chdir File.dirname(__FILE__)
+external = File.read '../../Top_Level_Vagrantfile'
+eval external

--- a/puppet.pp
+++ b/puppet.pp
@@ -33,8 +33,18 @@ if $operatingsystem == 'Ubuntu' or $operatingsystem == 'Debian'{
   exec { "apt-get update":
          path => "/usr/bin"
   }
-  notice("Installing XXpython-httplib2 for ${operatingsystem} ${operatingsystemrelease}")
-  package { "python-httplib2":
+  $httplib_package = $lsbdistcodename ? {
+    'bullseye' => 'python3-httplib2',
+    default    => 'python-httplib2'
+  }
+  notice("Installing ${httplib_package} for ${operatingsystem} ${operatingsystemrelease}")
+  package { $httplib_package:
+    ensure => present,
+    before => Package["couchbase-server"]
+  }
+  # not all versions of Ubuntu ship with it
+  notice("Installing libtinfo5 for ${operatingsystem} ${operatingsystemrelease}")
+  package { "libtinfo5":
     ensure => present,
     before => Package["couchbase-server"]
   }
@@ -105,7 +115,8 @@ package { "libssl":
 	    '7' => "libssl1.0.0",
 	    '8' => "libssl1.0.0",
 	    '9' => "libssl1.1",
-	    '10' => "libssl1.1"},
+	    '10' => "libssl1.1",
+      '11' => "libssl1.1"},
         'OpenSuSE' => "openssl",
     },
     ensure => present,


### PR DESCRIPTION
Note that, since centos7 is no longer supported, there are no RHEL-family boxes for morpheus-testing for now - https://issues.couchbase.com/browse/CBSP-4171 will look into adding RHEL boxes instead.